### PR TITLE
Second channel for rdb

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3033,6 +3033,7 @@ standardConfig static_configs[] = {
     createBoolConfig("lazyfree-lazy-user-flush", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.lazyfree_lazy_user_flush , 0, NULL, NULL),
     createBoolConfig("repl-disable-tcp-nodelay", NULL, MODIFIABLE_CONFIG, server.repl_disable_tcp_nodelay, 0, NULL, NULL),
     createBoolConfig("repl-diskless-sync", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.repl_diskless_sync, 1, NULL, NULL),
+    createBoolConfig("repl-second-conn-enabled", NULL, DEBUG_CONFIG | MODIFIABLE_CONFIG, server.second_conn_enabled, 1, NULL, NULL),
     createBoolConfig("aof-rewrite-incremental-fsync", NULL, MODIFIABLE_CONFIG, server.aof_rewrite_incremental_fsync, 1, NULL, NULL),
     createBoolConfig("no-appendfsync-on-rewrite", NULL, MODIFIABLE_CONFIG, server.aof_no_fsync_on_rewrite, 0, NULL, NULL),
     createBoolConfig("cluster-require-full-coverage", NULL, MODIFIABLE_CONFIG, server.cluster_require_full_coverage, 1, NULL, NULL),

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -3448,12 +3448,11 @@ void killRDBChild(void) {
 
 int sendCurentOffsetToSlave(client* slave) {
     char buf[128];
-    int buflen = 0;
-    memcpy(buf, "+ENDOFFSET", 10);
-    memcpy(buf + (buflen += 10), &server.db->id, sizeof(int));
-    memcpy(buf + (buflen += sizeof(int)), server.replid, CONFIG_RUN_ID_SIZE+1);
-    memcpy(buf + (buflen += CONFIG_RUN_ID_SIZE+1), &server.master_repl_offset, sizeof(long long)); 
-    buflen += sizeof(long long);
+    int buflen;
+    /* Send to replica End Offset rsponse with structure
+     * $ENDOFF:<end-offset> <master-repl-id> <current-db-id> */
+    buflen = snprintf(buf,sizeof(buf),"$ENDOFF:%lld %s %d\t\n",server.master_repl_offset,server.replid,server.db->id);
+    serverLog(LL_NOTICE,"Sending end offset response to replica %s", replicationGetSlaveName(slave));
     if (connWrite(slave->conn,buf,buflen) != buflen) {
         freeClientAsync(slave);
         return C_ERR;

--- a/src/server.h
+++ b/src/server.h
@@ -449,6 +449,7 @@ typedef enum {
     REPL_SEC_CONN_RECEIVE_CAPA_REPLY,       /* Wait for REPLCONF reply */
     REPL_SEC_CONN_RECEIVE_RDBONLY_REPLY,    /* Wait for REPLCONF reply */
     REPL_SEC_CONN_RECEIVE_OFFSET_REPLY,     /* Wait for REPLCONF reply */
+    REPL_SEC_CONN_RECEIVE_ENDOFF,           /* Wait for $ENDOFF reply */
     REPL_SEC_CONN_RDB_LOAD_MAIN_CONN_SEND_PSYNC, /* Same as REPL_STATE_SEND_PSYNC but during RDB load */
     REPL_SEC_CONN_RDB_LOAD_MAIN_CONN_PSYNC_REPLY,/* Same as REPL_STATE_RECEIVE_PSYNC_REPLY but during RDB load */
 } repl_state;


### PR DESCRIPTION
Second channel for RDB
    
    In this commit:
    1. Feature flag
    2. SyncWithMaster flow changes:
            a. REPLCONF has two new arguments `end-offset` and `psync-only`
            `psync-only`- used by main connection (psync connection). Replica
            uses this command in order to inform master that the replica don't want
            to full sunc with this connection.
            `end-offset`- used by second connection (RDB connection) in
            order to ask the master to include the end offset details before
            the RDB is sent.
            b. If full sync is needed create a full sync connection and
            initialize it
    
     3. readSyncBulkPayload flow changes:
            a. Read +ENDOFFSET response at the beginning of snapshot read.
            b. Initiate the main connection for psync session. This initiate
            sever.master struct.
     4. rdbSaveToSlaveSockets changes:
            Before start syncing, send the current master info.
    
    In the upcomming commits:
    1. Use the replica connection directly by child process.
    2. Allow diskless sync in master side.
    3. Mitigations
    4. Tests
    5. Expose to master that both connection belong to the same replica